### PR TITLE
remove redundant responses

### DIFF
--- a/cautils/opapolicy/datastructuresmethods.go
+++ b/cautils/opapolicy/datastructuresmethods.go
@@ -85,11 +85,11 @@ func (controlReport *ControlReport) ListControlsInputKinds() []string {
 
 func (controlReport *ControlReport) Passed() bool {
 	for i := range controlReport.RuleReports {
-		if len(controlReport.RuleReports[i].RuleResponses) == 0 {
-			return true
+		if len(controlReport.RuleReports[i].RuleResponses) != 0 {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 func (controlReport *ControlReport) Warning() bool {

--- a/cautils/opapolicy/datastructuresmethods.go
+++ b/cautils/opapolicy/datastructuresmethods.go
@@ -127,9 +127,6 @@ func (ruleReport *RuleReport) GetNumberOfFailedResources() int {
 			if !ruleReport.DeleteIfRedundantResponse(&ruleReport.RuleResponses[i], i) {
 				sum++
 			}
-			// else {
-			// i--
-			// }
 		}
 	}
 	return sum


### PR DESCRIPTION
responses that come from the same k8sresource (like containers from the same workload) - merged to one response