### PR TITLE
Bugfix: correctly compare filepath.Ext() result

### DIFF
--- a/cautils/scaninfo.go
+++ b/cautils/scaninfo.go
@@ -66,12 +66,12 @@ func (scanInfo *ScanInfo) setOutputFile() {
 		return
 	}
 	if scanInfo.Format == "json" {
-		if filepath.Ext(scanInfo.Output) != "json" {
+		if filepath.Ext(scanInfo.Output) != ".json" {
 			scanInfo.Output += ".json"
 		}
 	}
 	if scanInfo.Format == "junit" {
-		if filepath.Ext(scanInfo.Output) != "xml" {
+		if filepath.Ext(scanInfo.Output) != ".xml" {
 			scanInfo.Output += ".xml"
 		}
 	}


### PR DESCRIPTION
Closes #81.

setOutputFile() will incorrectly append .json to an --output
value that already has it. This is because
https://pkg.go.dev/path/filepath#Ext result includes
the ., whereas the current logic only tests against
json, not .json.