### PR TITLE
fix version for cli in docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,8 +71,8 @@ jobs:
         run: echo quay.io/armosec/kubescape:v1.0.${{ github.run_number }} > build_tag.txt
 
       - name: Build the Docker image
-        run: docker build . --file build/Dockerfile --tag $(cat build_tag.txt)
-      
+        run: docker build . --file build/Dockerfile --tag $(cat build_tag.txt) --build-arg run_number=${{ github.run_number }}
+
       - name: Re-Tag Image to latest
         run: docker tag $(cat build_tag.txt) quay.io/armosec/kubescape:latest
 

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -50,7 +50,7 @@ jobs:
         run: echo quay.io/armosec/kubescape:dev-v1.0.${{ github.run_number }} > build_tag.txt
 
       - name: Build the Docker image
-        run: docker build . --file build/Dockerfile --tag $(cat build_tag.txt)
+        run: docker build . --file build/Dockerfile --tag $(cat build_tag.txt) --build-arg run_number=${{ github.run_number }}
       
       - name: Login to Quay.io
         env: # Or as an environment variable

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:1.17-alpine as builder
 #ENV GOPROXY=https://goproxy.io,direct
+ARG run_number
+ENV RELEASE=v1.0.${run_number}
 ENV GO111MODULE=
 
 ENV CGO_ENABLED=0

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,10 @@
 FROM golang:1.17-alpine as builder
 #ENV GOPROXY=https://goproxy.io,direct
+
 ARG run_number
+
 ENV RELEASE=v1.0.${run_number}
+
 ENV GO111MODULE=
 
 ENV CGO_ENABLED=0


### PR DESCRIPTION
When running `docker run quay.io/armosec/kubescape version`
The current output is:
```
Warning: You are not updated to the latest release: v1.0.128
Your current version is: None
```
This is due to the build container missing 
RELEASE environment variable