### PR TITLE
Prometheus metrics server and example deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *vender*
 *.pyc*
 .idea
+*~
+.#*

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ kubescape scan framework nsa --format junit --output results.xml
 kubescape scan framework nsa --format prometheus
 ```
 
+See [docs/prometheus.md](docs/prometheus.md) for more information on using kubescape in prometheus.
+
 #### Scan with exceptions, objects with exceptions will be presented as `exclude` and not `fail`
 ```
 kubescape scan framework nsa --exceptions examples/exceptions.json

--- a/cautils/customerloader.go
+++ b/cautils/customerloader.go
@@ -132,7 +132,7 @@ func (c *EmptyConfig) GetBackendAPI() getter.IBackend         { return nil } // 
 func (c *EmptyConfig) GetClusterName() string                 { return adoptClusterName(k8sinterface.GetClusterName()) }
 func (c *EmptyConfig) GenerateURL() {
 	message := fmt.Sprintf("\nCheckout for more cool features: https://%s\n", getter.GetArmoAPIConnector().GetFrontendURL())
-	InfoTextDisplay(os.Stdout, fmt.Sprintf("\n%s\n", message))
+	InfoTextDisplay(os.Stderr, fmt.Sprintf("\n%s\n", message))
 }
 
 // ======================================================================================

--- a/cautils/getter/armoapi.go
+++ b/cautils/getter/armoapi.go
@@ -110,7 +110,7 @@ func (armoAPI *ArmoAPI) GetFramework(name string) (*reporthandling.Framework, er
 	if err = JSONDecoder(respStr).Decode(framework); err != nil {
 		return nil, err
 	}
-	SaveFrameworkInFile(framework, GetDefaultPath(name+".json"))
+	SaveFrameworkInFile(framework, GetDefaultPath(GetFilename(name)))
 
 	return framework, err
 }

--- a/cautils/getter/getpoliciesutils.go
+++ b/cautils/getter/getpoliciesutils.go
@@ -10,9 +10,14 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/armosec/opa-utils/reporthandling"
 )
+
+func GetFilename(name string) string {
+	return strings.ToLower(name) + ".json"
+}
 
 func GetDefaultPath(name string) string {
 	defaultfilePath := filepath.Join(DefaultLocalStore, name)
@@ -20,6 +25,14 @@ func GetDefaultPath(name string) string {
 		defaultfilePath = filepath.Join(homeDir, defaultfilePath)
 	}
 	return defaultfilePath
+}
+
+func GetTimestamp(path string) time.Time {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return time.Unix(0,0)
+	}
+	return stat.ModTime()
 }
 
 // Save control as json in file

--- a/cautils/versioncheck.go
+++ b/cautils/versioncheck.go
@@ -79,11 +79,11 @@ func (v *VersionCheckHandler) CheckLatestVersion(versionData *VersionCheckReques
 	}
 
 	if latestVersion.ClientUpdate != "" {
-		fmt.Println(warningMessage(latestVersion.Client, latestVersion.ClientUpdate))
+		fmt.Fprintf(os.Stderr, warningMessage(latestVersion.Client, latestVersion.ClientUpdate))
 	}
 
 	if latestVersion.FrameworkUpdate != "" {
-		fmt.Println(warningMessage(latestVersion.Framework, latestVersion.FrameworkUpdate))
+		fmt.Fprintf(os.Stderr, warningMessage(latestVersion.Framework, latestVersion.FrameworkUpdate))
 	}
 	return nil
 }
@@ -108,5 +108,5 @@ func (v *VersionCheckHandler) getLatestVersion(versionData *VersionCheckRequest)
 }
 
 func warningMessage(kind, release string) string {
-	return fmt.Sprintf("Warning: '%s' is not updated to the latest release: '%s'", kind, release)
+	return fmt.Sprintf("Warning: '%s' is not updated to the latest release: '%s'\n", kind, release)
 }

--- a/clihandler/cmd/download.go
+++ b/clihandler/cmd/download.go
@@ -29,7 +29,7 @@ var downloadCmd = &cobra.Command{
 			downloadInfo.FrameworkName = strings.ToLower(args[1])
 			g := getter.NewDownloadReleasedPolicy()
 			if downloadInfo.Path == "" {
-				downloadInfo.Path = getter.GetDefaultPath(downloadInfo.FrameworkName + ".json")
+				downloadInfo.Path = getter.GetDefaultPath(getter.GetFilename(downloadInfo.FrameworkName))
 			}
 			frameworks, err := g.GetFramework(downloadInfo.FrameworkName)
 			if err != nil {
@@ -43,7 +43,7 @@ var downloadCmd = &cobra.Command{
 			downloadInfo.ControlName = strings.ToLower(args[1])
 			g := getter.NewDownloadReleasedPolicy()
 			if downloadInfo.Path == "" {
-				downloadInfo.Path = getter.GetDefaultPath(downloadInfo.ControlName + ".json")
+				downloadInfo.Path = getter.GetDefaultPath(getter.GetFilename(downloadInfo.ControlName))
 			}
 			controls, err := g.GetControl(downloadInfo.ControlName)
 			if err != nil {

--- a/clihandler/cmd/metrics.go
+++ b/clihandler/cmd/metrics.go
@@ -1,0 +1,154 @@
+ package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+	"net/http"
+	"github.com/armosec/kubescape/cautils/getter"
+)
+
+type scanDetails struct {
+	frameworkControl string
+	name string
+	excludedNamespaces string
+	useExceptions string
+}
+
+type serverDetails struct {
+	port uint16
+	scanInterval uint
+	updateInterval uint
+	scan scanDetails
+}
+
+type serverState struct {
+	valid bool
+	response string
+	mtx sync.Mutex
+}
+
+var server serverDetails
+var state serverState
+
+// metricsCmd represents the metrics command
+var metricsCmd = &cobra.Command{
+	Use:   "metrics <command>",
+	Short: "Metrics runs kubescape as a web server",
+	Long:  `An http server will start on the given port`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 2 {
+			return fmt.Errorf("requires two arguments : framework/control <framework-name>/<control-name>")
+		}
+		if !strings.EqualFold(args[0], "framework") && !strings.EqualFold(args[0], "control") {
+			return fmt.Errorf("invalid parameter '%s'. Supported parameters: framework, control", args[0])
+		}
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		http.HandleFunc("/metrics", metrics)
+		http.HandleFunc("/livez", livez)
+		http.HandleFunc("/readyz", readyz)
+		server.scan.frameworkControl = args[0]
+		server.scan.name = args[1]
+
+		state.valid = false
+		go backgroundScanner(
+			server.scan,
+			time.Duration(server.scanInterval) * time.Second,
+			time.Duration(server.updateInterval) * time.Second)
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", server.port), nil))
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(metricsCmd)
+	metricsCmd.PersistentFlags().Uint16VarP(&server.port, "port", "p", 80, "Port to serve http on")
+	metricsCmd.PersistentFlags().UintVarP(&server.scanInterval, "interval", "i", 300, "Interval in seconds between running scans")
+	metricsCmd.PersistentFlags().UintVarP(&server.updateInterval, "update", "u", 60*60*4, "Interval in seconds between downloading the framework/control data")
+	metricsCmd.PersistentFlags().StringVarP(&server.scan.excludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. Recommended: kube-system, kube-public")
+	metricsCmd.PersistentFlags().StringVar(&server.scan.useExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from Armo management portal")
+}
+
+
+func logEvent(path string, r *http.Request, code int) {
+	log.Printf("%s %s %s response: %d\n", r.Host, r.Method, path, code)
+}
+
+func metrics(w http.ResponseWriter, r *http.Request) {
+	state.mtx.Lock()
+	if !state.valid {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		logEvent("/metrics", r, http.StatusServiceUnavailable)
+	} else {
+		fmt.Fprintf(w, state.response)
+		logEvent("/metrics", r, 200)
+	}
+	state.mtx.Unlock()
+}
+
+func livez(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+	// logEvent("/livez", r, http.StatusNoContent)
+}
+
+func readyz(w http.ResponseWriter, r *http.Request) {
+	state.mtx.Lock()
+	if !state.valid {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		// logEvent("/readyz", r, http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusNoContent)
+		// logEvent("/readyz", r, http.StatusNoContent)
+	}
+	state.mtx.Unlock()
+}
+
+func backgroundScanner(scan scanDetails, interval time.Duration, update time.Duration) {
+	// Scan then run timed scans
+	scanner(scan, update)
+	ticker := time.NewTicker(interval)
+	for _ = range ticker.C {
+		scanner(scan, update)
+	}
+}
+
+func scanner(scan scanDetails, update time.Duration) {
+	if time.Now().After(getter.GetTimestamp(getter.GetDefaultPath(getter.GetFilename(scan.name))).Add(update)) {
+		log.Println("Downloading updated framework")
+		cmd := exec.Command(os.Args[0], "download", scan.frameworkControl, scan.name)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		out, _ := cmd.Output()
+		log.Printf("%s\n", out)
+		log.Printf("%s\n", stderr.String())
+	}
+	log.Println("Running scan")
+	args := []string{"scan", "-s", "-f", "prometheus", scan.frameworkControl, scan.name}
+	if scan.excludedNamespaces != "" {
+		args = append(args, []string{"--exclude-namespaces", scan.excludedNamespaces}...)
+	}
+	if scan.useExceptions != "" {
+		args = append(args, []string{"--exceptions", scan.useExceptions}...)
+	}
+	cmd := exec.Command(os.Args[0], args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	state.mtx.Lock()
+	state.response = string(out)
+	if err != nil {
+		state.valid = false
+	} else {
+		state.valid = true
+	}
+	state.mtx.Unlock()
+	log.Printf("%s\n", stderr.String())
+}

--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -1,0 +1,69 @@
+# Using kubescape with prometheus
+
+This is a complimentary way of securing your cluster for existing deployments, and for finding violations when the rules have changed after deployment. Alertmanager can then inform you of new violations found because the frameworks have improved.
+
+Running kubescape in CI should be also deployed.
+
+You can also use this to take a cluster with problems and easilly pick which areas to tackle and fix and see those fixes getting solved automatically - perhaps tackling all of one type of violation at a time rather than per application/namespace.
+
+## Metrics server
+
+Running "kubescape metrics framework nsa" will start up a webserver on port 80 which will serve the following paths
+
+/metrics - will respond with prometheus metrics once they have been scanned. This will respond 503 before scanning completes or if the last scan failed.
+/livez - will respond 204 OK every time
+/readyz - will respond 204 once metrics are available
+
+| flag                        | default             | description                                                                                                            |
+|-----------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------|
+| `-p`/`--port`               | 80                  | Port number to serve on.                                                                                               |
+| `-i`/`--interval`           | 300                 | Interval between scans in seconds. If the scan takes longer than this, then the scans will be continous.               |
+| `-u`/`--update`             | 14400               | Interval between attempts to download new scan rules in seconds. Default is 4 hours.                                   |
+| `-e`/`--exclude-namespaces` | Scan all namespaces | Namespaces to exclude from scanning. Recommended to exclude `kube-system` and `kube-public` namespaces                 |
+| `--exceptions`              |                     | Path to an [exceptions obj](examples/exceptions.json). If not set will download exceptions from Armo management portal |
+
+Note: there is no https support at this time
+
+The metrics command does not serve other formats of kubescape output.
+
+## Installation into kubernetes
+
+This way of running kubescape is designed to be used inside kubernetes, and this documents how to use it with the [prometheus operator](https://prometheus-operator.dev/). The author recommends [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md) as a quick way of getting started. It should be possible use it in other ways with prometheus.
+
+The files in [examples/kubernetes](../examples/kubernetes) will deploy one instance of kubescape to run the nsa framework on your cluster. 
+
+### [namespace.yaml](../examples/kubernetes/namespace.yaml)
+Creates as separate namespace to run kubescape in.
+
+### [clusterrole.yaml](../examples/kubernetes/clusterrole.yaml)
+Creates a role that allows kubescape to read all resources in the cluster - necessary for it to operate.
+
+### [serviceaccount.yaml](../examples/kubernetes/serviceaccount.yaml)
+Creates an account for kubescape to run as.
+
+### [clusterrolebinding.yaml](../examples/kubernetes/clusterrolebinding.yaml)
+Binds the cluster roles to the service account so that kubescape can read all resources.
+
+### [deployment.yaml](../examples/kubernetes/deployment.yaml)
+Creates a pod running kubescape.
+
+*NOTE* You can configure the arguments to kubescape here by changing args. This example deployment runs the nsa framework against everything in the cluster. You may well wish to change this. You may well wish to run scans less frequently to save CPU resources in your cluster, especially once you have fixed most violations, you can do this by adding "-i", "1800" to set it to every 30 minutes for example.
+
+### [service.yaml](../examples/kubernetes/service.yaml)
+Creates a service to allow prometheus to access the http port on the kubescape metrics server.
+
+### [servicemonitor.yaml](../examples/kubernetes/servicemonitor.yaml)
+This tells preometheus to scrape kubescape every 'interval' seconds. Note that scraping kubescape at different frequencies does *not* change how often kubescape scans the cluster.
+
+In order for this to be deployed to the kubescape namespace instead of the prometheus namespace you'll need to allow the prometheus operator to scan for service monitors in all namespaces. With [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/README.md) you set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues to false
+
+### [networkpolicy.yaml](../examples/kubernetes/networkpolicy.yaml)
+
+If you don't have a valid networkpolicy the nsa framework will tell you that kubescape is violating. You almost certainly will have to change the example network policy to make the labels match those for your own prometheus. If you don't prometheus will be unable to scrape kubescape, and you won't get /metrics log messages in kubescape's log.
+
+I'd suggest not deploying this object to start with until you have the rest working.
+
+### [prometheusrule.yaml](../examples/kubernetes/prometheusrule.yaml)
+
+Some example rules for prometheus to generate alerts when violations are found. These examples would probably want refining for your own deployment.
+

--- a/examples/kubernetes/clusterrole.yaml
+++ b/examples/kubernetes/clusterrole.yaml
@@ -1,0 +1,8 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubescape-clusterroles
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "list", "describe"]

--- a/examples/kubernetes/clusterrolebinding.yaml
+++ b/examples/kubernetes/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kubescape-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubescape-clusterroles
+subjects:
+- kind: ServiceAccount
+  name: kubescape
+  namespace: kubescape

--- a/examples/kubernetes/deployment.yaml
+++ b/examples/kubernetes/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1 
+kind: Deployment
+metadata:
+  name: kubescape
+  namespace: kubescape
+  labels:
+    app: kubescape
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubescape
+  template:
+    metadata:
+      labels:
+        app: kubescape
+    spec:
+      serviceAccount: kubescape
+      automountServiceAccountToken: true
+      containers:
+        - name: kubescape
+          image: quay.io/armosec/kubescape
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 80
+            name: http
+          command: ["kubescape"]
+          args: ["metrics", "framework", "nsa"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 80
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /livez
+              port: 80
+              scheme: HTTP
+            periodSeconds: 5
+          resources:
+            requests:
+              cpu: 300m
+              memory: 1024Mi
+            limits:
+              cpu: 1000m
+              memory: 2048Mi
+          volumeMounts:
+            - mountPath: /root/.kubescape
+              name: frameworks-tmp
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - name: frameworks-tmp
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/examples/kubernetes/namespace.yaml
+++ b/examples/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubescape

--- a/examples/kubernetes/networkpolicy.yaml
+++ b/examples/kubernetes/networkpolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: kubescape
+  namespace: kubescape
+spec:
+  podSelector:
+    matchLabels:
+      app: kubescape
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    - namespaceSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - protocol: TCP
+      port: 80
+  egress:
+  - {}

--- a/examples/kubernetes/prometheusrule.yaml
+++ b/examples/kubernetes/prometheusrule.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kubescape-rules
+  namespace: kubescape
+spec:
+  groups:
+  - name: kubescape.rules
+    rules:
+    - alert: kubescapeFailedObject
+      annotations:
+        description: |-
+          {{ $labels.groupVersionKind }}/{{ $labels.name }} in namespace {{ $labels.exported_namespace }} failed the {{ $labels.control }} control in the {{ $labels.framework }} Kubescape framework
+        summary: Kubescape framework violation
+      expr: count by(framework,control,groupVersionKind,exported_namespace,name) (kubescape_object_failed_count{}) > 0
+      labels:
+        severity: warning
+    - alert: kubescapeResourcesFound
+      annotations:
+        description: |-
+          {{ $value }} violations for Control {{ $labels.control }} in the {{ $labels.framework }} Kubescape framework
+        summary: Kubescape framework violation
+      expr: count by(framework,control) (kubescape_resources_found_count) > 0
+      labels:
+        severity: warning

--- a/examples/kubernetes/service.yaml
+++ b/examples/kubernetes/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubescape
+  namespace: kubescape
+  labels:
+    app: kubescape
+spec:
+  type: ClusterIP
+  selector:
+    app: kubescape
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP

--- a/examples/kubernetes/serviceaccount.yaml
+++ b/examples/kubernetes/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: kubescape
+  name: kubescape
+  namespace: kubescape
+automountServiceAccountToken: false

--- a/examples/kubernetes/servicemonitor.yaml
+++ b/examples/kubernetes/servicemonitor.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: kubescape
+  name: kubescape
+  namespace: kubescape
+spec:
+  endpoints:
+  - interval: 60s
+    path: /metrics
+    scrapeTimeout: 10s
+    targetPort: 80
+  jobLabel: kubescape
+  namespaceSelector:
+    matchNames:
+    - kubescape
+  selector:
+    matchLabels:
+      app: kubescape


### PR DESCRIPTION
#202 parts 2 and 3

This adds a metrics command to kubescape to start a web server. It will scan in the background and update frameworks in the background, whilst serving scan results on /metrics

Also includes an example deployment of this.