### PR TITLE
Dev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/armosec/armoapi-go v0.0.23
 	github.com/armosec/k8s-interface v0.0.37
-	github.com/armosec/opa-utils v0.0.64
+	github.com/armosec/opa-utils v0.0.65
 	github.com/armosec/rbac-utils v0.0.9
 	github.com/armosec/utils-go v0.0.3
 	github.com/briandowns/spinner v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,9 @@ github.com/armosec/armoapi-go v0.0.23/go.mod h1:iaVVGyc23QGGzAdv4n+szGQg3Rbpixn9
 github.com/armosec/k8s-interface v0.0.8/go.mod h1:xxS+V5QT3gVQTwZyAMMDrYLWGrfKOpiJ7Jfhfa0w9sM=
 github.com/armosec/k8s-interface v0.0.37 h1:EPjzozpkVw0SmizoALmVg6D8VZIX7gcgTg+WxA02jNc=
 github.com/armosec/k8s-interface v0.0.37/go.mod h1:vHxGWqD/uh6+GQb9Sqv7OGMs+Rvc2dsFVc0XtgRh1ZU=
-github.com/armosec/opa-utils v0.0.64 h1:RdiFpy6QqoTD2e9k5eIwgDrTWctUL215QI3ust8tnD0=
 github.com/armosec/opa-utils v0.0.64/go.mod h1:6tQP8UDq2EvEfSqh8vrUdr/9QVSCG4sJfju1SXQOn4c=
+github.com/armosec/opa-utils v0.0.65 h1:wz9ruf/EjIqoedFBC0lnByKwD9BTlda4l+ircjniwP8=
+github.com/armosec/opa-utils v0.0.65/go.mod h1:6tQP8UDq2EvEfSqh8vrUdr/9QVSCG4sJfju1SXQOn4c=
 github.com/armosec/rbac-utils v0.0.1/go.mod h1:pQ8CBiij8kSKV7aeZm9FMvtZN28VgA7LZcYyTWimq40=
 github.com/armosec/rbac-utils v0.0.9 h1:rIOWp4K7BELUNX32ktSjVbb8d/0SpH7W76W6Tf+8rzw=
 github.com/armosec/rbac-utils v0.0.9/go.mod h1:Ex/IdGWhGv9HZq6Hs8N/ApzCKSIvpNe/ETqDfnuyah0=

--- a/opaprocessor/processorhandler.go
+++ b/opaprocessor/processorhandler.go
@@ -8,6 +8,8 @@ import (
 	"github.com/armosec/kubescape/cautils"
 	"github.com/armosec/opa-utils/objectsenvelopes"
 	"github.com/armosec/opa-utils/reporthandling"
+	"github.com/armosec/opa-utils/score"
+
 	"github.com/golang/glog"
 
 	"github.com/armosec/k8s-interface/k8sinterface"
@@ -66,7 +68,8 @@ func (opaHandler *OPAProcessorHandler) ProcessRulesListenner() {
 
 		// update score
 		// opap.updateScore()
-
+		scoreutil := score.NewScore(opaSessionObj.AllResources)
+		scoreutil.Calculate(opaSessionObj.PostureReport.FrameworkReports)
 		// report
 		*opaHandler.reportResults <- opaSessionObj
 	}

--- a/opaprocessor/processorhandlerutils.go
+++ b/opaprocessor/processorhandlerutils.go
@@ -28,7 +28,7 @@ func (opap *OPAProcessor) updateResults() {
 		reporthandling.SetUniqueResourcesCounter(&opap.PostureReport.FrameworkReports[f])
 
 		// set default score
-		reporthandling.SetDefaultScore(&opap.PostureReport.FrameworkReports[f])
+		// reporthandling.SetDefaultScore(&opap.PostureReport.FrameworkReports[f])
 	}
 }
 

--- a/resultshandling/printer/summary.go
+++ b/resultshandling/printer/summary.go
@@ -7,13 +7,14 @@ import (
 	"github.com/armosec/opa-utils/reporthandling"
 )
 
-type Summary map[string]ControlSummary
+type Summary map[string]ResultSummary
 
 func NewSummary() Summary {
-	return make(map[string]ControlSummary)
+	return make(map[string]ResultSummary)
 }
 
-type ControlSummary struct {
+type ResultSummary struct {
+	RiskScore         float32
 	TotalResources    int
 	TotalFailed       int
 	TotalWarning      int
@@ -31,7 +32,7 @@ type WorkloadSummary struct {
 	status   string
 }
 
-func (controlSummary *ControlSummary) ToSlice() []string {
+func (controlSummary *ResultSummary) ToSlice() []string {
 	s := []string{}
 	s = append(s, fmt.Sprintf("%d", controlSummary.TotalFailed))
 	s = append(s, fmt.Sprintf("%d", controlSummary.TotalWarning))

--- a/resultshandling/results.go
+++ b/resultshandling/results.go
@@ -34,7 +34,11 @@ func (resultsHandler *ResultsHandler) HandleResults(scanInfo *cautils.ScanInfo) 
 	}
 
 	// TODO - get score from table
-	score := CalculatePostureScore(opaSessionObj.PostureReport)
+	var score float32 = 0
+	for i := range opaSessionObj.PostureReport.FrameworkReports {
+		score += opaSessionObj.PostureReport.FrameworkReports[i].Score
+	}
+	score /= float32(len(opaSessionObj.PostureReport.FrameworkReports))
 	resultsHandler.printerObj.Score(score)
 
 	return score


### PR DESCRIPTION
changes:

risk-score based on opa-utils.
score now affected by score factors(baseScore), failed & all input resources of each control.
score consider the scale of the cluster as well (number of replicas)

prettyprint
prettyprint summary is now print each control risk-score(%) instead of %success.
generateRow receives a print object instead of various fields which come from print object/subobject itself thus preventing function duplication/ break api in the future