### PR TITLE
move kube-host-sensor manifest to indipendent yaml file with embed capability

### DIFF
--- a/hostsensorutils/hostsensor.yaml
+++ b/hostsensorutils/hostsensor.yaml
@@ -1,6 +1,4 @@
-package hostsensorutils
-
-const hostSensorYAML = `apiVersion: v1
+apiVersion: v1
 kind: Namespace
 metadata:
   labels:
@@ -62,4 +60,4 @@ spec:
         name: host-filesystem
       hostNetwork: true
       hostPID: true
-      hostIPC: true`
+      hostIPC: true

--- a/hostsensorutils/hostsensordeploy.go
+++ b/hostsensorutils/hostsensordeploy.go
@@ -1,6 +1,7 @@
 package hostsensorutils
 
 import (
+	_ "embed"
 	"fmt"
 	"io"
 	"strings"
@@ -16,6 +17,11 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	appsapplyv1 "k8s.io/client-go/applyconfigurations/apps/v1"
 	coreapplyv1 "k8s.io/client-go/applyconfigurations/core/v1"
+)
+
+var (
+	//go:embed hostsensor.yaml
+	hostSensorYAML string
 )
 
 type HostSensorHandler struct {


### PR DESCRIPTION
This could be useful to separate data from code.
In this way we have a dedicated `yaml` file to describe the `DaemonSet` which is going to be installed in the cluster.