### PR TITLE
Helm: add value to set frameworks

### DIFF
--- a/examples/helm_chart/Chart.yaml
+++ b/examples/helm_chart/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/examples/helm_chart/README.md
+++ b/examples/helm_chart/README.md
@@ -1,6 +1,6 @@
 # kubescape
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.128](https://img.shields.io/badge/AppVersion-v1.0.128-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.128](https://img.shields.io/badge/AppVersion-v1.0.128-informational?style=flat-square)
 
 Kubescape is the first open-source tool for testing if Kubernetes is deployed securely according to multiple frameworks regulatory, customized company policies and DevSecOps best practices, such as the  [NSA-CISA](https://www.armosec.io/blog/kubernetes-hardening-guidance-summary-by-armo) and the [MITRE ATT&CK®](https://www.microsoft.com/security/blog/2021/03/23/secure-containerized-environments-with-updated-threat-matrix-for-kubernetes/) . Kubescape scans K8s clusters, YAML files, and HELM charts, and detect misconfigurations and software vulnerabilities at early stages of the CI/CD pipeline and provides a risk score instantly and risk trends over time. Kubescape integrates natively with other DevOps tools, including Jenkins, CircleCI and Github workflows.
 
@@ -10,6 +10,7 @@ Kubescape is the first open-source tool for testing if Kubernetes is deployed se
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | configMap | object | `{"create":true,"params":{"clusterName":"<MyK8sClusterName>","customerGUID":"<MyGUID>,"}}` | ARMO customer information |
+| frameworks | string | `"nsa"` | Comma-separated list of frameworks to scan (i.e. "nsa,mitre,armobest") |
 | fullnameOverride | string | `""` |  |
 | image | object | `{"imageName":"kubescape","pullPolicy":"IfNotPresent","repository":"quay.io/armosec","tag":"latest"}` | Image and version to deploy |
 | imagePullSecrets | list | `[]` |  |

--- a/examples/helm_chart/README.md
+++ b/examples/helm_chart/README.md
@@ -10,7 +10,7 @@ Kubescape is the first open-source tool for testing if Kubernetes is deployed se
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | configMap | object | `{"create":true,"params":{"clusterName":"<MyK8sClusterName>","customerGUID":"<MyGUID>,"}}` | ARMO customer information |
-| frameworks | string | `"nsa"` | Comma-separated list of frameworks to scan (i.e. "nsa,mitre,armobest") |
+| frameworks | list | `["nsa"]` | List of frameworks to scan |
 | fullnameOverride | string | `""` |  |
 | image | object | `{"imageName":"kubescape","pullPolicy":"IfNotPresent","repository":"quay.io/armosec","tag":"latest"}` | Image and version to deploy |
 | imagePullSecrets | list | `[]` |  |

--- a/examples/helm_chart/templates/cronjob.yaml
+++ b/examples/helm_chart/templates/cronjob.yaml
@@ -15,7 +15,7 @@ spec:
             image: "{{ .Values.image.repository }}/{{ .Values.image.imageName }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             command: ["/bin/sh", "-c"]
-            args: ["kubescape scan framework nsa --submit"]
+            args: ["kubescape scan framework {{ .Values.frameworks }} --submit"]
             volumeMounts:
             - name: kubescape-config-volume
               mountPath: /root/.kubescape/config.json

--- a/examples/helm_chart/templates/cronjob.yaml
+++ b/examples/helm_chart/templates/cronjob.yaml
@@ -1,3 +1,8 @@
+{{ $frameworks := "" }}
+{{ range .Values.frameworks }}
+{{ $frameworks = cat $frameworks . }}
+{{ end }}
+{{- $frameworks = $frameworks | trim | replace " " "," }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -15,7 +20,7 @@ spec:
             image: "{{ .Values.image.repository }}/{{ .Values.image.imageName }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             command: ["/bin/sh", "-c"]
-            args: ["kubescape scan framework {{ .Values.frameworks }} --submit"]
+            args: ["kubescape scan framework {{ $frameworks }} --submit"]
             volumeMounts:
             - name: kubescape-config-volume
               mountPath: /root/.kubescape/config.json

--- a/examples/helm_chart/values.yaml
+++ b/examples/helm_chart/values.yaml
@@ -15,6 +15,9 @@
 #      UTC * * * * *
 schedule: "* * 1 * *"
 
+# -- Comma-separated list of frameworks to scan (i.e. "nsa,mitre,armobest")
+frameworks: nsa
+
 # -- Image and version to deploy
 image:
   repository: quay.io/armosec

--- a/examples/helm_chart/values.yaml
+++ b/examples/helm_chart/values.yaml
@@ -15,8 +15,9 @@
 #      UTC * * * * *
 schedule: "* * 1 * *"
 
-# -- Comma-separated list of frameworks to scan (i.e. "nsa,mitre,armobest")
-frameworks: nsa
+# -- List of frameworks to scan
+frameworks:
+- nsa
 
 # -- Image and version to deploy
 image:


### PR DESCRIPTION
This commit adds a new value to the Helm chart which allows the user to specify specific frameworks to scan. Right now only `nsa` is hardcoded into the CronJob, so this allows for greater customization for users who want to use MITRE, ArmoBest, or custom frameworks.