### PR TITLE
Remove need to tap from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,9 @@ Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 
 ## Install on macOS
 
-1. ```
-    brew tap armosec/kubescape
-    ```
-2. ```
-    brew install kubescape
-    ```
+```
+brew install kubescape
+```
 
 ## Flags
 


### PR DESCRIPTION
The official homebrew tap now has kubescape, added in commit https://github.com/Homebrew/homebrew-core/commit/dc96c2c3194165448ebd26e5858a8b6e0647d108.