### PR TITLE
Fix argument validation for framework/control

### DIFF
--- a/clihandler/cmd/control.go
+++ b/clihandler/cmd/control.go
@@ -40,8 +40,10 @@ var controlCmd = &cobra.Command{
 		if len(args) > 0 {
 			controls := strings.Split(args[0], ",")
 			if len(controls) > 1 {
-				if controls[1] == "" {
-					return fmt.Errorf("usage: <control-0>,<control-1>")
+				for _, control := range controls {
+					if control == "" {
+						return fmt.Errorf("usage: <control-0>,<control-1>")
+					}
 				}
 			}
 		} else {

--- a/clihandler/cmd/framework.go
+++ b/clihandler/cmd/framework.go
@@ -51,8 +51,10 @@ var frameworkCmd = &cobra.Command{
 		if len(args) > 0 {
 			frameworks := strings.Split(args[0], ",")
 			if len(frameworks) > 1 {
-				if frameworks[1] == "" {
-					return fmt.Errorf("usage: <framework-0>,<framework-1>")
+				for _, framework := range frameworks {
+					if framework == "" {
+						return fmt.Errorf("usage: <framework-0>,<framework-1>")
+					}
 				}
 			}
 		} else {


### PR DESCRIPTION
Closes #412 

kubescape fails with a proper error message if any of the framework/control is empty -

![image](https://user-images.githubusercontent.com/52544819/155263740-5c37b260-6241-40c3-a81d-61a121a5abf9.png)

![image](https://user-images.githubusercontent.com/52544819/155263811-dcf634ab-8706-4b97-b2cd-3b895c1ca475.png)

