### PR TITLE
Change fail-threshold type to float

### DIFF
--- a/cautils/scaninfo.go
+++ b/cautils/scaninfo.go
@@ -73,7 +73,7 @@ type ScanInfo struct {
 	IncludeNamespaces  string      // DEPRECATED?
 	InputPatterns      []string    // Yaml files input patterns
 	Silent             bool        // Silent mode - Do not print progress logs
-	FailThreshold      uint16      // Failure score threshold
+	FailThreshold      float32     // Failure score threshold
 	Submit             bool        // Submit results to Armo BE
 	HostSensorEnabled  BoolPtrFlag // Deploy ARMO K8s host sensor to collect data from certain controls
 	HostSensorYamlPath string      // Path to hostsensor file

--- a/clihandler/cmd/scan.go
+++ b/clihandler/cmd/scan.go
@@ -68,7 +68,7 @@ func init() {
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseExceptions, "exceptions", "", "Path to an exceptions obj. If not set will download exceptions from ARMO management portal")
 	scanCmd.PersistentFlags().StringVar(&scanInfo.UseArtifactsFrom, "use-artifacts-from", "", "Load artifacts from local directory. If not used will download them")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.ExcludedNamespaces, "exclude-namespaces", "e", "", "Namespaces to exclude from scanning. Recommended: kube-system,kube-public")
-	scanCmd.PersistentFlags().Uint16VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
+	scanCmd.PersistentFlags().Float32VarP(&scanInfo.FailThreshold, "fail-threshold", "t", 100, "Failure threshold is the percent above which the command fails and returns exit code 1")
 	scanCmd.PersistentFlags().StringVarP(&scanInfo.Format, "format", "f", "pretty-printer", `Output format. Supported formats: "pretty-printer","json","junit","prometheus","pdf"`)
 	scanCmd.PersistentFlags().StringVar(&scanInfo.IncludeNamespaces, "include-namespaces", "", "scan specific namespaces. e.g: --include-namespaces ns-a,ns-b")
 	scanCmd.PersistentFlags().BoolVarP(&scanInfo.Local, "keep-local", "", false, "If you do not want your Kubescape results reported to Armo backend. Use this flag if you ran with the '--submit' flag in the past and you do not want to submit your current scan results")

--- a/clihandler/initcli.go
+++ b/clihandler/initcli.go
@@ -153,7 +153,7 @@ func ScanCliSetup(scanInfo *cautils.ScanInfo) error {
 	interfaces.report.DisplayReportURL()
 
 	if score > float32(scanInfo.FailThreshold) {
-		return fmt.Errorf("scan risk-score %.2f is above permitted threshold %d", score, scanInfo.FailThreshold)
+		return fmt.Errorf("scan risk-score %.2f is above permitted threshold %.2f", score, scanInfo.FailThreshold)
 	}
 
 	return nil


### PR DESCRIPTION
Our resources number is volatile. Thus, we would like to have a precise value in the fail-threshold test