### PR TITLE
cli: added support for no color

### DIFF
--- a/cautils/logger/methods.go
+++ b/cautils/logger/methods.go
@@ -23,6 +23,8 @@ type ILogger interface {
 
 	SetWriter(w *os.File)
 	GetWriter() *os.File
+
+	DisableColor(flag bool)
 }
 
 var l ILogger

--- a/cautils/logger/prettylogger/colors.go
+++ b/cautils/logger/prettylogger/colors.go
@@ -29,3 +29,9 @@ func prefix(l helpers.Level) func(w io.Writer, format string, a ...interface{}) 
 	}
 	return message
 }
+
+func DisableColor(flag bool) {
+	if flag {
+		color.NoColor = true
+	}
+}

--- a/cautils/logger/prettylogger/logger.go
+++ b/cautils/logger/prettylogger/logger.go
@@ -26,6 +26,10 @@ func (pl *PrettyLogger) GetLevel() string     { return pl.level.String() }
 func (pl *PrettyLogger) SetWriter(w *os.File) { pl.writer = w }
 func (pl *PrettyLogger) GetWriter() *os.File  { return pl.writer }
 
+func (pl *PrettyLogger) DisableColor(flag bool) {
+	DisableColor(flag)
+}
+
 func (pl *PrettyLogger) SetLevel(level string) error {
 	pl.level = helpers.ToLevel(level)
 	if pl.level == helpers.UnknownLevel {

--- a/cautils/logger/zaplogger/logger.go
+++ b/cautils/logger/zaplogger/logger.go
@@ -37,6 +37,8 @@ func (zl *ZapLogger) SetWriter(w *os.File) {}
 func (zl *ZapLogger) GetWriter() *os.File  { return nil }
 func GetWriter() *os.File                  { return nil }
 
+func (zl *ZapLogger) DisableColor(flag bool) {}
+
 func (zl *ZapLogger) SetLevel(level string) error {
 	l := zapcore.Level(1)
 	err := l.Set(level)

--- a/cautils/scaninfo.go
+++ b/cautils/scaninfo.go
@@ -54,9 +54,11 @@ func (bpf *BoolPtrFlag) Set(val string) error {
 }
 
 type RootInfo struct {
-	Logger   string // logger level
-	CacheDir string // cached dir
+	Logger       string // logger level
+	CacheDir     string // cached dir
+	DisableColor bool   // Disable Color
 }
+
 type ScanInfo struct {
 	Getters
 	PolicyIdentifier   []reporthandling.PolicyIdentifier

--- a/clihandler/cmd/root.go
+++ b/clihandler/cmd/root.go
@@ -56,6 +56,8 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&rootInfo.Logger, "logger", "l", helpers.InfoLevel.String(), fmt.Sprintf("Logger level. Supported: %s [$KS_LOGGER]", strings.Join(helpers.SupportedLevels(), "/")))
 	rootCmd.PersistentFlags().StringVar(&rootInfo.CacheDir, "cache-dir", getter.DefaultLocalStore, "Cache directory [$KS_CACHE_DIR]")
+	rootCmd.PersistentFlags().BoolVarP(&rootInfo.DisableColor, "disable-color", "", false, "Disable Color output for logging")
+
 }
 
 func initLogger() {
@@ -68,6 +70,9 @@ func initLoggerLevel() {
 	} else if l := os.Getenv("KS_LOGGER"); l != "" {
 		rootInfo.Logger = l
 	}
+
+	logger.L().DisableColor(rootInfo.DisableColor)
+
 	if err := logger.L().SetLevel(rootInfo.Logger); err != nil {
 		logger.L().Fatal(fmt.Sprintf("supported levels: %s", strings.Join(helpers.SupportedLevels(), "/")), helpers.Error(err))
 	}


### PR DESCRIPTION
Using commandline flag users can now disable colored output
in logging.

Fixes: #434

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>