### PR TITLE
Added Severity Column with colored text

### DIFF
--- a/core/pkg/resultshandling/printer/v2/controltable.go
+++ b/core/pkg/resultshandling/printer/v2/controltable.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/armosec/opa-utils/reporthandling/apis"
 	"github.com/armosec/opa-utils/reporthandling/results/v1/reportsummary"
+	"github.com/fatih/color"
 )
 
 func generateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfoMap map[string]string) []string {
@@ -12,6 +14,14 @@ func generateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfoMa
 	row = append(row, fmt.Sprintf("%d", controlSummary.NumberOfResources().Failed()))
 	row = append(row, fmt.Sprintf("%d", controlSummary.NumberOfResources().Excluded()))
 	row = append(row, fmt.Sprintf("%d", controlSummary.NumberOfResources().All()))
+
+	if controlSummary.GetStatus().IsPassed() {
+		row = append(row, color.CyanString("Passed"))
+	} else if controlSummary.GetStatus().IsSkipped() {
+		row = append(row, "skipped")
+	} else {
+		row = append(row, setColor(apis.ControlSeverityToString(controlSummary.GetScoreFactor())))
+	}
 
 	if !controlSummary.GetStatus().IsSkipped() {
 		row = append(row, fmt.Sprintf("%d", int(controlSummary.GetScore()))+"%")
@@ -27,6 +37,21 @@ func generateRow(controlSummary reportsummary.IControlSummary, infoToPrintInfoMa
 	return row
 }
 
+func setColor(controlSeverity string) string {
+	switch controlSeverity {
+	case "Critical":
+		return color.New(color.FgRed, color.Bold).Add(color.Underline).SprintFunc()(controlSeverity)
+	case "High":
+		return color.New(color.FgRed, color.Bold).SprintFunc()(controlSeverity)
+	case "Medium":
+		return color.New(color.FgYellow, color.Bold).SprintFunc()(controlSeverity)
+	case "Low":
+		return color.New(color.FgGreen, color.Bold).SprintFunc()(controlSeverity)
+	default:
+		return color.New(color.FgBlue, color.Bold).SprintFunc()(controlSeverity)
+	}
+}
+
 func getSortedControlsNames(controls reportsummary.ControlSummaries) []string {
 	controlNames := make([]string, 0, len(controls))
 	for k := range controls {
@@ -38,5 +63,5 @@ func getSortedControlsNames(controls reportsummary.ControlSummaries) []string {
 }
 
 func getControlTableHeaders() []string {
-	return []string{"CONTROL NAME", "FAILED RESOURCES", "EXCLUDED RESOURCES", "ALL RESOURCES", "% RISK-SCORE", "INFO"}
+	return []string{"CONTROL NAME", "FAILED RESOURCES", "EXCLUDED RESOURCES", "ALL RESOURCES", "SEVERITY", "% RISK-SCORE", "INFO"}
 }

--- a/core/pkg/resultshandling/printer/v2/prettyprinter.go
+++ b/core/pkg/resultshandling/printer/v2/prettyprinter.go
@@ -172,6 +172,7 @@ func generateFooter(summaryDetails *reportsummary.SummaryDetails) []string {
 	row = append(row, fmt.Sprintf("%d", summaryDetails.NumberOfResources().Failed()))
 	row = append(row, fmt.Sprintf("%d", summaryDetails.NumberOfResources().Excluded()))
 	row = append(row, fmt.Sprintf("%d", summaryDetails.NumberOfResources().All()))
+	row = append(row, " ")
 	row = append(row, fmt.Sprintf("%.2f%s", summaryDetails.Score, "%"))
 	row = append(row, " ")
 


### PR DESCRIPTION
This PR adds the **Severity** column to the Results table. 
The Severity column was present in the Web console but wasn't displayed in the Results table till now.

As per our conversation with @dwertent, instead of colouring the **Risk Score** column, we came up with the conclusion of colouring the **Severity** column.

**Screen shot**: 
![pr](https://user-images.githubusercontent.com/47265560/161451726-d169b6fe-e570-46ec-ae25-f68502a4d3b9.png)

Fixes https://github.com/armosec/kubescape/issues/320
Signed-off by: akundu@redhat.com