### PR TITLE
Check for empty k8s resources in controls related to armo resources 

### DIFF
--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -66,7 +66,8 @@ func mapControlToInfo(mapResourceToControls map[string][]string, infoMap map[str
 	for resource, statusInfo := range infoMap {
 		controls := mapResourceToControls[resource]
 		for _, control := range controls {
-			if isEmptyResources(controlSummary[control].ResourceCounters) {
+			counters := controlSummary[control].ResourceCounters
+			if isEmptyResources(&counters) {
 				controlToInfoMap[control] = statusInfo
 			}
 		}
@@ -74,8 +75,8 @@ func mapControlToInfo(mapResourceToControls map[string][]string, infoMap map[str
 	return controlToInfoMap
 }
 
-func isEmptyResources(counters reportsummary.ResourceCounters) bool {
-	return counters.FailedResources == 0 && counters.ExcludedResources == 0 && counters.PassedResources == 0
+func isEmptyResources(counters reportsummary.ICounters) bool {
+	return counters.Failed() == 0 && counters.Excluded() == 0 && counters.Passed() == 0
 }
 
 func getAllSupportedObjects(k8sResources *cautils.K8SResources, armoResources *cautils.ArmoResources, allResources map[string]workloadinterface.IMetadata, rule *reporthandling.PolicyRule) []workloadinterface.IMetadata {

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -64,11 +64,14 @@ func (opap *OPAProcessor) updateResults() {
 func mapControlToInfo(mapResourceToControls map[string][]string, infoMap map[string]apis.StatusInfo, controlSummary reportsummary.ControlSummaries) map[string]apis.StatusInfo {
 	controlToInfoMap := make(map[string]apis.StatusInfo)
 	for resource, statusInfo := range infoMap {
-		controls := mapResourceToControls[resource]
-		for _, control := range controls {
-			counters := controlSummary[control].ResourceCounters
-			if isEmptyResources(&counters) {
-				controlToInfoMap[control] = statusInfo
+		controlIDs := mapResourceToControls[resource]
+		for _, controlID := range controlIDs {
+			resources := controlSummary.GetControl(reportsummary.EControlCriteriaID, controlID).NumberOfResources()
+			if resources != nil {
+				// Check that there are no K8s resources too
+				if isEmptyResources(resources) {
+					controlToInfoMap[controlID] = statusInfo
+				}
 			}
 		}
 	}

--- a/core/pkg/opaprocessor/processorhandlerutils.go
+++ b/core/pkg/opaprocessor/processorhandlerutils.go
@@ -66,13 +66,15 @@ func mapControlToInfo(mapResourceToControls map[string][]string, infoMap map[str
 	for resource, statusInfo := range infoMap {
 		controlIDs := mapResourceToControls[resource]
 		for _, controlID := range controlIDs {
-			resources := controlSummary.GetControl(reportsummary.EControlCriteriaID, controlID).NumberOfResources()
-			if resources != nil {
+			ctrl := controlSummary.GetControl(reportsummary.EControlCriteriaID, controlID)
+			if ctrl != nil {
+				resources := ctrl.NumberOfResources()
 				// Check that there are no K8s resources too
 				if isEmptyResources(resources) {
 					controlToInfoMap[controlID] = statusInfo
 				}
 			}
+
 		}
 	}
 	return controlToInfoMap


### PR DESCRIPTION
The current behaviour of kubescape is to list the control as "skipped" if it gets as input a host sensor resource (or any other armo resource) and the relevant flag was not used. 
This PR fixes it in a case where there are also k8s resources as input (so the control is not skipped). This behaviour is needed for control c-0079