### PR TITLE
support env with http

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -88,7 +88,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().MarkHidden("silent")         // this flag should be deprecated since we added the --logger support
 	// scanCmd.PersistentFlags().MarkHidden("format-version") // meant for testing different output approaches and not for common use
 
-	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "enable-host-scan", "", "Deploy ARMO K8s host-sensor daemonset in the scanned cluster. Deleting it right after we collecting the data. Required to collect valuable data from cluster nodes for certain controls. Yaml file: https://raw.githubusercontent.com/armosec/kubescape/master/hostsensorutils/hostsensor.yaml")
+	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "enable-host-scan", "", "Deploy ARMO K8s host-sensor daemonset in the scanned cluster. Deleting it right after we collecting the data. Required to collect valuable data from cluster nodes for certain controls. Yaml file: https://github.com/armosec/kubescape/blob/master/core/pkg/hostsensorutils/hostsensor.yaml")
 	hostF.NoOptDefVal = "true"
 	hostF.DefValue = "false, for no TTY in stdin"
 

--- a/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
@@ -11,14 +11,8 @@ import (
 )
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
-	urlObj := url.URL{}
-	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
-	if strings.Contains(urlObj.Host, "http://") {
-		urlObj.Scheme = "http"
-		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
-	} else {
-		urlObj.Scheme = "https"
-	}
+	urlObj := parseHost(getter.GetArmoAPIConnector().GetReportReceiverURL())
+
 	urlObj.Path = "/k8s/postureReport"
 	q := urlObj.Query()
 	q.Add("customerGUID", uuid.MustParse(report.customerGUID).String())
@@ -28,7 +22,17 @@ func (report *ReportEventReceiver) initEventReceiverURL() {
 
 	report.eventReceiverURL = &urlObj
 }
-
+func parseHost(host string) url.URL {
+	urlObj := url.URL{}
+	if strings.Contains(host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+		urlObj.Host = host
+	}
+	return urlObj
+}
 func hostToString(host *url.URL, reportID string) string {
 	q := host.Query()
 	q.Add("reportID", reportID) // TODO - do we add the reportID?

--- a/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/armosec/k8s-interface/workloadinterface"
 	"github.com/armosec/kubescape/v2/core/cautils/getter"
@@ -11,9 +12,13 @@ import (
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
 	urlObj := url.URL{}
-
-	urlObj.Scheme = "https"
 	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
+	if strings.Contains(urlObj.Host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+	}
 	urlObj.Path = "/k8s/postureReport"
 	q := urlObj.Query()
 	q.Add("customerGUID", uuid.MustParse(report.customerGUID).String())

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 
 	"github.com/armosec/k8s-interface/workloadinterface"
 	"github.com/armosec/kubescape/v2/core/cautils"
@@ -89,15 +88,7 @@ func (report *ReportEventReceiver) prepareReport(opaSessionObj *cautils.OPASessi
 }
 
 func (report *ReportEventReceiver) GetURL() string {
-	u := url.URL{}
-	u.Host = getter.GetArmoAPIConnector().GetFrontendURL()
-	if strings.Contains(u.Host, "http://") {
-		u.Scheme = "http"
-		u.Host = strings.Replace(u.Host, "http://", "", 1)
-	} else {
-		u.Scheme = "https"
-	}
-
+	u := parseHost(getter.GetArmoAPIConnector().GetFrontendURL())
 	q := u.Query()
 
 	if report.customerAdminEMail != "" || report.token == "" { // data has been submitted

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/armosec/k8s-interface/workloadinterface"
 	"github.com/armosec/kubescape/v2/core/cautils"
@@ -89,8 +90,13 @@ func (report *ReportEventReceiver) prepareReport(opaSessionObj *cautils.OPASessi
 
 func (report *ReportEventReceiver) GetURL() string {
 	u := url.URL{}
-	u.Scheme = "https"
 	u.Host = getter.GetArmoAPIConnector().GetFrontendURL()
+	if strings.Contains(u.Host, "http://") {
+		u.Scheme = "http"
+		u.Host = strings.Replace(u.Host, "http://", "", 1)
+	} else {
+		u.Scheme = "https"
+	}
 
 	q := u.Query()
 

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
@@ -11,14 +11,7 @@ import (
 )
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
-	urlObj := url.URL{}
-	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
-	if strings.Contains(urlObj.Host, "http://") {
-		urlObj.Scheme = "http"
-		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
-	} else {
-		urlObj.Scheme = "https"
-	}
+	urlObj := parseHost(getter.GetArmoAPIConnector().GetReportReceiverURL())
 	urlObj.Path = "/k8s/v2/postureReport"
 
 	q := urlObj.Query()
@@ -30,6 +23,17 @@ func (report *ReportEventReceiver) initEventReceiverURL() {
 	report.eventReceiverURL = &urlObj
 }
 
+func parseHost(host string) url.URL {
+	urlObj := url.URL{}
+	if strings.Contains(host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+		urlObj.Host = host
+	}
+	return urlObj
+}
 func hostToString(host *url.URL, reportID string) string {
 	q := host.Query()
 	q.Add("reportGUID", reportID) // TODO - do we add the reportID?

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/armosec/kubescape/v2/core/cautils"
 	"github.com/armosec/kubescape/v2/core/cautils/getter"
@@ -11,9 +12,13 @@ import (
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
 	urlObj := url.URL{}
-
-	urlObj.Scheme = "https"
 	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
+	if strings.Contains(urlObj.Host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+	}
 	urlObj.Path = "/k8s/v2/postureReport"
 
 	q := urlObj.Query()


### PR DESCRIPTION
Useful for running with --env=http://localhost:7555. 
Up until now it was needed to switch all https to http