### PR TITLE
Fix eks and support http for all endpoints

### DIFF
--- a/cmd/scan/scan.go
+++ b/cmd/scan/scan.go
@@ -88,7 +88,7 @@ func GetScanCommand(ks meta.IKubescape) *cobra.Command {
 	scanCmd.PersistentFlags().MarkHidden("silent")         // this flag should be deprecated since we added the --logger support
 	// scanCmd.PersistentFlags().MarkHidden("format-version") // meant for testing different output approaches and not for common use
 
-	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "enable-host-scan", "", "Deploy ARMO K8s host-sensor daemonset in the scanned cluster. Deleting it right after we collecting the data. Required to collect valuable data from cluster nodes for certain controls. Yaml file: https://raw.githubusercontent.com/armosec/kubescape/master/hostsensorutils/hostsensor.yaml")
+	hostF := scanCmd.PersistentFlags().VarPF(&scanInfo.HostSensorEnabled, "enable-host-scan", "", "Deploy ARMO K8s host-sensor daemonset in the scanned cluster. Deleting it right after we collecting the data. Required to collect valuable data from cluster nodes for certain controls. Yaml file: https://github.com/armosec/kubescape/blob/master/core/pkg/hostsensorutils/hostsensor.yaml")
 	hostF.NoOptDefVal = "true"
 	hostF.DefValue = "false, for no TTY in stdin"
 

--- a/core/cautils/getter/armoapiutils.go
+++ b/core/cautils/getter/armoapiutils.go
@@ -9,12 +9,23 @@ import (
 	"strings"
 )
 
+func parseHost(urlObj *url.URL) {
+	if strings.Contains(urlObj.Host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+		urlObj.Host = strings.Replace(urlObj.Host, "https://", "", 1)
+	}
+}
+
 var NativeFrameworks = []string{"nsa", "mitre", "armobest", "devopsbest"}
 
 func (armoAPI *ArmoAPI) getFrameworkURL(frameworkName string) string {
 	u := url.URL{}
-	u.Scheme = "https"
-	u.Host = armoAPI.apiURL
+	u.Host = armoAPI.GetAPIURL()
+	parseHost(&u)
+
 	u.Path = "api/v1/armoFrameworks"
 	q := u.Query()
 	q.Add("customerGUID", armoAPI.getCustomerGUIDFallBack())
@@ -31,8 +42,9 @@ func (armoAPI *ArmoAPI) getFrameworkURL(frameworkName string) string {
 
 func (armoAPI *ArmoAPI) getListFrameworkURL() string {
 	u := url.URL{}
-	u.Scheme = "https"
-	u.Host = armoAPI.apiURL
+	u.Host = armoAPI.GetAPIURL()
+	parseHost(&u)
+
 	u.Path = "api/v1/armoFrameworks"
 	q := u.Query()
 	q.Add("customerGUID", armoAPI.getCustomerGUIDFallBack())
@@ -42,8 +54,8 @@ func (armoAPI *ArmoAPI) getListFrameworkURL() string {
 }
 func (armoAPI *ArmoAPI) getExceptionsURL(clusterName string) string {
 	u := url.URL{}
-	u.Scheme = "https"
-	u.Host = armoAPI.apiURL
+	u.Host = armoAPI.GetAPIURL()
+	parseHost(&u)
 	u.Path = "api/v1/armoPostureExceptions"
 
 	q := u.Query()
@@ -58,8 +70,8 @@ func (armoAPI *ArmoAPI) getExceptionsURL(clusterName string) string {
 
 func (armoAPI *ArmoAPI) exceptionsURL(exceptionsPolicyName string) string {
 	u := url.URL{}
-	u.Scheme = "https"
-	u.Host = armoAPI.apiURL
+	u.Host = armoAPI.GetAPIURL()
+	parseHost(&u)
 	u.Path = "api/v1/postureExceptionPolicy"
 
 	q := u.Query()
@@ -81,8 +93,8 @@ func (armoAPI *ArmoAPI) getAccountConfigDefault(clusterName string) string {
 
 func (armoAPI *ArmoAPI) getAccountConfig(clusterName string) string {
 	u := url.URL{}
-	u.Scheme = "https"
-	u.Host = armoAPI.apiURL
+	u.Host = armoAPI.GetAPIURL()
+	parseHost(&u)
 	u.Path = "api/v1/armoCustomerConfiguration"
 
 	q := u.Query()
@@ -97,8 +109,8 @@ func (armoAPI *ArmoAPI) getAccountConfig(clusterName string) string {
 
 func (armoAPI *ArmoAPI) getAccountURL() string {
 	u := url.URL{}
-	u.Scheme = "https"
-	u.Host = armoAPI.apiURL
+	u.Host = armoAPI.GetAPIURL()
+	parseHost(&u)
 	u.Path = "api/v1/createTenant"
 	return u.String()
 }
@@ -106,7 +118,6 @@ func (armoAPI *ArmoAPI) getAccountURL() string {
 func (armoAPI *ArmoAPI) getApiToken() string {
 	u := url.URL{}
 	u.Scheme = "https"
-	u.Host = armoAPI.authURL
 	u.Path = "frontegg/identity/resources/auth/v1/api-token"
 	return u.String()
 }
@@ -114,7 +125,6 @@ func (armoAPI *ArmoAPI) getApiToken() string {
 func (armoAPI *ArmoAPI) getOpenidCustomers() string {
 	u := url.URL{}
 	u.Scheme = "https"
-	u.Host = armoAPI.apiURL
 	u.Path = "api/v1/openid_customers"
 	return u.String()
 }

--- a/core/pkg/resultshandling/reporter/v1/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v1/reporteventreceiver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/armosec/kubescape/v2/core/cautils/getter"
 	"github.com/armosec/kubescape/v2/core/cautils/logger"
 	"github.com/armosec/kubescape/v2/core/cautils/logger/helpers"
+	v2 "github.com/armosec/kubescape/v2/core/pkg/resultshandling/reporter/v2"
 	"github.com/armosec/opa-utils/reporthandling"
 	"github.com/google/uuid"
 )
@@ -140,8 +141,8 @@ func (report *ReportEventReceiver) generateMessage() {
 	message := "You can see the results in a user-friendly UI, choose your preferred compliance framework, check risk results history and trends, manage exceptions, get remediation recommendations and much more by registering here:"
 
 	u := url.URL{}
-	u.Scheme = "https"
 	u.Host = getter.GetArmoAPIConnector().GetFrontendURL()
+	v2.ParseHost(&u)
 
 	if report.customerAdminEMail != "" {
 		logger.L().Debug("", helpers.String("account ID", report.customerGUID))

--- a/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
@@ -2,16 +2,18 @@ package v1
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/armosec/k8s-interface/workloadinterface"
 	"github.com/armosec/kubescape/v2/core/cautils/getter"
+	v2 "github.com/armosec/kubescape/v2/core/pkg/resultshandling/reporter/v2"
 	"github.com/armosec/opa-utils/reporthandling"
 	"github.com/google/uuid"
 )
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
-	urlObj := parseHost(getter.GetArmoAPIConnector().GetReportReceiverURL())
+	urlObj := url.URL{}
+	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
+	v2.ParseHost(&urlObj)
 
 	urlObj.Path = "/k8s/postureReport"
 	q := urlObj.Query()
@@ -22,17 +24,7 @@ func (report *ReportEventReceiver) initEventReceiverURL() {
 
 	report.eventReceiverURL = &urlObj
 }
-func parseHost(host string) url.URL {
-	urlObj := url.URL{}
-	if strings.Contains(host, "http://") {
-		urlObj.Scheme = "http"
-		urlObj.Host = strings.Replace(host, "http://", "", 1)
-	} else {
-		urlObj.Scheme = "https"
-		urlObj.Host = host
-	}
-	return urlObj
-}
+
 func hostToString(host *url.URL, reportID string) string {
 	q := host.Query()
 	q.Add("reportID", reportID) // TODO - do we add the reportID?

--- a/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
@@ -11,14 +11,8 @@ import (
 )
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
-	urlObj := url.URL{}
-	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
-	if strings.Contains(urlObj.Host, "http://") {
-		urlObj.Scheme = "http"
-		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
-	} else {
-		urlObj.Scheme = "https"
-	}
+	urlObj := parseHost(getter.GetArmoAPIConnector().GetReportReceiverURL())
+
 	urlObj.Path = "/k8s/postureReport"
 	q := urlObj.Query()
 	q.Add("customerGUID", uuid.MustParse(report.customerGUID).String())
@@ -28,7 +22,17 @@ func (report *ReportEventReceiver) initEventReceiverURL() {
 
 	report.eventReceiverURL = &urlObj
 }
-
+func parseHost(host string) url.URL {
+	urlObj := url.URL{}
+	if strings.Contains(host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+		urlObj.Host = host
+	}
+	return urlObj
+}
 func hostToString(host *url.URL, reportID string) string {
 	q := host.Query()
 	q.Add("reportID", reportID) // TODO - do we add the reportID?

--- a/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v1/reporteventreceiverutils.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/armosec/k8s-interface/workloadinterface"
 	"github.com/armosec/kubescape/v2/core/cautils/getter"
@@ -11,9 +12,13 @@ import (
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
 	urlObj := url.URL{}
-
-	urlObj.Scheme = "https"
 	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
+	if strings.Contains(urlObj.Host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+	}
 	urlObj.Path = "/k8s/postureReport"
 	q := urlObj.Query()
 	q.Add("customerGUID", uuid.MustParse(report.customerGUID).String())

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 
 	"github.com/armosec/k8s-interface/workloadinterface"
 	"github.com/armosec/kubescape/v2/core/cautils"
@@ -89,15 +88,7 @@ func (report *ReportEventReceiver) prepareReport(opaSessionObj *cautils.OPASessi
 }
 
 func (report *ReportEventReceiver) GetURL() string {
-	u := url.URL{}
-	u.Host = getter.GetArmoAPIConnector().GetFrontendURL()
-	if strings.Contains(u.Host, "http://") {
-		u.Scheme = "http"
-		u.Host = strings.Replace(u.Host, "http://", "", 1)
-	} else {
-		u.Scheme = "https"
-	}
-
+	u := parseHost(getter.GetArmoAPIConnector().GetFrontendURL())
 	q := u.Query()
 
 	if report.customerAdminEMail != "" || report.token == "" { // data has been submitted

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/armosec/k8s-interface/workloadinterface"
 	"github.com/armosec/kubescape/v2/core/cautils"
@@ -89,8 +90,13 @@ func (report *ReportEventReceiver) prepareReport(opaSessionObj *cautils.OPASessi
 
 func (report *ReportEventReceiver) GetURL() string {
 	u := url.URL{}
-	u.Scheme = "https"
 	u.Host = getter.GetArmoAPIConnector().GetFrontendURL()
+	if strings.Contains(u.Host, "http://") {
+		u.Scheme = "http"
+		u.Host = strings.Replace(u.Host, "http://", "", 1)
+	} else {
+		u.Scheme = "https"
+	}
 
 	q := u.Query()
 

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiver.go
@@ -88,7 +88,9 @@ func (report *ReportEventReceiver) prepareReport(opaSessionObj *cautils.OPASessi
 }
 
 func (report *ReportEventReceiver) GetURL() string {
-	u := parseHost(getter.GetArmoAPIConnector().GetFrontendURL())
+	u := url.URL{}
+	u.Host = getter.GetArmoAPIConnector().GetFrontendURL()
+	ParseHost(&u)
 	q := u.Query()
 
 	if report.customerAdminEMail != "" || report.token == "" { // data has been submitted

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
@@ -11,14 +11,7 @@ import (
 )
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
-	urlObj := url.URL{}
-	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
-	if strings.Contains(urlObj.Host, "http://") {
-		urlObj.Scheme = "http"
-		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
-	} else {
-		urlObj.Scheme = "https"
-	}
+	urlObj := parseHost(getter.GetArmoAPIConnector().GetReportReceiverURL())
 	urlObj.Path = "/k8s/v2/postureReport"
 
 	q := urlObj.Query()
@@ -30,6 +23,17 @@ func (report *ReportEventReceiver) initEventReceiverURL() {
 	report.eventReceiverURL = &urlObj
 }
 
+func parseHost(host string) url.URL {
+	urlObj := url.URL{}
+	if strings.Contains(host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+		urlObj.Host = host
+	}
+	return urlObj
+}
 func hostToString(host *url.URL, reportID string) string {
 	q := host.Query()
 	q.Add("reportGUID", reportID) // TODO - do we add the reportID?

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/armosec/kubescape/v2/core/cautils"
 	"github.com/armosec/kubescape/v2/core/cautils/getter"
@@ -11,9 +12,13 @@ import (
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
 	urlObj := url.URL{}
-
-	urlObj.Scheme = "https"
 	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
+	if strings.Contains(urlObj.Host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+	}
 	urlObj.Path = "/k8s/v2/postureReport"
 
 	q := urlObj.Query()

--- a/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
+++ b/core/pkg/resultshandling/reporter/v2/reporteventreceiverutils.go
@@ -2,7 +2,6 @@ package v2
 
 import (
 	"net/url"
-	"strings"
 
 	"github.com/armosec/kubescape/v2/core/cautils"
 	"github.com/armosec/kubescape/v2/core/cautils/getter"
@@ -11,9 +10,10 @@ import (
 )
 
 func (report *ReportEventReceiver) initEventReceiverURL() {
-	urlObj := parseHost(getter.GetArmoAPIConnector().GetReportReceiverURL())
+	urlObj := url.URL{}
+	urlObj.Host = getter.GetArmoAPIConnector().GetReportReceiverURL()
+	ParseHost(&urlObj)
 	urlObj.Path = "/k8s/v2/postureReport"
-
 	q := urlObj.Query()
 	q.Add("customerGUID", uuid.MustParse(report.customerGUID).String())
 	q.Add("clusterName", report.clusterName)
@@ -23,17 +23,6 @@ func (report *ReportEventReceiver) initEventReceiverURL() {
 	report.eventReceiverURL = &urlObj
 }
 
-func parseHost(host string) url.URL {
-	urlObj := url.URL{}
-	if strings.Contains(host, "http://") {
-		urlObj.Scheme = "http"
-		urlObj.Host = strings.Replace(host, "http://", "", 1)
-	} else {
-		urlObj.Scheme = "https"
-		urlObj.Host = host
-	}
-	return urlObj
-}
 func hostToString(host *url.URL, reportID string) string {
 	q := host.Query()
 	q.Add("reportGUID", reportID) // TODO - do we add the reportID?

--- a/core/pkg/resultshandling/reporter/v2/utils.go
+++ b/core/pkg/resultshandling/reporter/v2/utils.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"net/url"
 	"strings"
 )
 
@@ -20,4 +21,14 @@ func maskID(id string) string {
 	}
 
 	return strings.TrimSuffix(str, sep)
+}
+
+func ParseHost(urlObj *url.URL) {
+	if strings.Contains(urlObj.Host, "http://") {
+		urlObj.Scheme = "http"
+		urlObj.Host = strings.Replace(urlObj.Host, "http://", "", 1)
+	} else {
+		urlObj.Scheme = "https"
+		urlObj.Host = strings.Replace(urlObj.Host, "https://", "", 1)
+	}
 }

--- a/core/pkg/resultshandling/reporter/v2/utils_test.go
+++ b/core/pkg/resultshandling/reporter/v2/utils_test.go
@@ -1,0 +1,38 @@
+package v2
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseHost(t *testing.T) {
+	urlObj := url.URL{}
+
+	urlObj.Host = "http://localhost:7555"
+	ParseHost(&urlObj)
+	assert.Equal(t, "http", urlObj.Scheme)
+	assert.Equal(t, "localhost:7555", urlObj.Host)
+
+	urlObj.Host = "https://localhost:7555"
+	ParseHost(&urlObj)
+	assert.Equal(t, "https", urlObj.Scheme)
+	assert.Equal(t, "localhost:7555", urlObj.Host)
+
+	urlObj.Host = "http://portal-dev.armo.cloud"
+	ParseHost(&urlObj)
+	assert.Equal(t, "http", urlObj.Scheme)
+	assert.Equal(t, "portal-dev.armo.cloud", urlObj.Host)
+
+	urlObj.Host = "https://portal-dev.armo.cloud"
+	ParseHost(&urlObj)
+	assert.Equal(t, "https", urlObj.Scheme)
+	assert.Equal(t, "portal-dev.armo.cloud", urlObj.Host)
+
+	urlObj.Host = "portal-dev.armo.cloud"
+	ParseHost(&urlObj)
+	assert.Equal(t, "https", urlObj.Scheme)
+	assert.Equal(t, "portal-dev.armo.cloud", urlObj.Host)
+
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/armosec/armoapi-go v0.0.73
 	github.com/armosec/go-git-url v0.0.4
-	github.com/armosec/k8s-interface v0.0.70
+	github.com/armosec/k8s-interface v0.0.73
 	github.com/armosec/opa-utils v0.0.137
 	github.com/armosec/rbac-utils v0.0.14
 	github.com/armosec/utils-go v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/armosec/armoapi-go v0.0.73
 	github.com/armosec/go-git-url v0.0.4
-	github.com/armosec/k8s-interface v0.0.73
+	github.com/armosec/k8s-interface v0.0.74
 	github.com/armosec/opa-utils v0.0.137
 	github.com/armosec/rbac-utils v0.0.14
 	github.com/armosec/utils-go v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -120,8 +120,9 @@ github.com/armosec/go-git-url v0.0.4 h1:emG9Yfl53rHpuX41fXLD92ehzhRoNSSnGT6Pr7og
 github.com/armosec/go-git-url v0.0.4/go.mod h1:PJqdEyJyFxTQvawBcyOM0Ies6+uezire5gpwfr1XX5M=
 github.com/armosec/k8s-interface v0.0.8/go.mod h1:xxS+V5QT3gVQTwZyAMMDrYLWGrfKOpiJ7Jfhfa0w9sM=
 github.com/armosec/k8s-interface v0.0.37/go.mod h1:vHxGWqD/uh6+GQb9Sqv7OGMs+Rvc2dsFVc0XtgRh1ZU=
-github.com/armosec/k8s-interface v0.0.70 h1:NU3UIaNl7H3hsRecwggiaQbZXTwXtOKg3GOBjq6/XJw=
 github.com/armosec/k8s-interface v0.0.70/go.mod h1:8NX4xWXh8mwW7QyZdZea1czNdM2azCK9BbUNmiZYXW0=
+github.com/armosec/k8s-interface v0.0.73 h1:L1W8irF4vttWoK2xa+VFxEO95g5IGP1+0DtQ7SMFKdA=
+github.com/armosec/k8s-interface v0.0.73/go.mod h1:8NX4xWXh8mwW7QyZdZea1czNdM2azCK9BbUNmiZYXW0=
 github.com/armosec/opa-utils v0.0.64/go.mod h1:6tQP8UDq2EvEfSqh8vrUdr/9QVSCG4sJfju1SXQOn4c=
 github.com/armosec/opa-utils v0.0.137 h1:KAkxWYnnTef8ofixJ198Zs4Xs7MOh32+yMUyFY7I8DA=
 github.com/armosec/opa-utils v0.0.137/go.mod h1:mCFQzz4E227f7V2jQVQ9XCivkNNK3UWCTaZ0HE5rBWk=

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/armosec/go-git-url v0.0.4/go.mod h1:PJqdEyJyFxTQvawBcyOM0Ies6+uezire5
 github.com/armosec/k8s-interface v0.0.8/go.mod h1:xxS+V5QT3gVQTwZyAMMDrYLWGrfKOpiJ7Jfhfa0w9sM=
 github.com/armosec/k8s-interface v0.0.37/go.mod h1:vHxGWqD/uh6+GQb9Sqv7OGMs+Rvc2dsFVc0XtgRh1ZU=
 github.com/armosec/k8s-interface v0.0.70/go.mod h1:8NX4xWXh8mwW7QyZdZea1czNdM2azCK9BbUNmiZYXW0=
-github.com/armosec/k8s-interface v0.0.73 h1:L1W8irF4vttWoK2xa+VFxEO95g5IGP1+0DtQ7SMFKdA=
-github.com/armosec/k8s-interface v0.0.73/go.mod h1:8NX4xWXh8mwW7QyZdZea1czNdM2azCK9BbUNmiZYXW0=
+github.com/armosec/k8s-interface v0.0.74 h1:qZ1bkQv9JLfpwzxNcTytpYQpHKTKZ5rIhMze8SU1cPI=
+github.com/armosec/k8s-interface v0.0.74/go.mod h1:8NX4xWXh8mwW7QyZdZea1czNdM2azCK9BbUNmiZYXW0=
 github.com/armosec/opa-utils v0.0.64/go.mod h1:6tQP8UDq2EvEfSqh8vrUdr/9QVSCG4sJfju1SXQOn4c=
 github.com/armosec/opa-utils v0.0.137 h1:KAkxWYnnTef8ofixJ198Zs4Xs7MOh32+yMUyFY7I8DA=
 github.com/armosec/opa-utils v0.0.137/go.mod h1:mCFQzz4E227f7V2jQVQ9XCivkNNK3UWCTaZ0HE5rBWk=


### PR DESCRIPTION
The implementation of the cluster name parsing didn't include the case where the name, region, id etc was separated by ':'.
The code is here: https://github.com/armosec/k8s-interface/commit/8fd094f4d0acab4156896687194dc5def8380d4a
