### PR TITLE
remove error when reading yaml

### DIFF
--- a/core/cautils/fileutils.go
+++ b/core/cautils/fileutils.go
@@ -148,8 +148,6 @@ func readYamlFile(yamlFile []byte) ([]workloadinterface.IMetadata, []error) {
 					yamlObjs = append(yamlObjs, o)
 				}
 			}
-		} else {
-			errs = append(errs, fmt.Errorf("failed to convert yaml file to map[string]interface, file content: %v", j))
 		}
 	}
 


### PR DESCRIPTION
Remove an error if we try to read YAML file which is not a map[string]interface{}