### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export CGO_ENABLED=1
 
 # build and install libgit2
 libgit2:
-	git submodule update --init --recursive
+	-git submodule update --init --recursive
 	cd git2go; make install-static
 
 # go build tags


### PR DESCRIPTION
To support the new build process in homebrew, we are not using the submodules, hence, adding a dash to ignore an error when git submodule command fails