### PR TITLE
helm chart name fix

### DIFF
--- a/core/pkg/resourcehandler/filesloader.go
+++ b/core/pkg/resourcehandler/filesloader.go
@@ -119,6 +119,7 @@ func (fileHandler *FileResourceHandler) GetResources(sessionObj *cautils.OPASess
 	helmSourceToWorkloads, helmSourceToChartName := cautils.LoadResourcesFromHelmCharts(path)
 	for source, ws := range helmSourceToWorkloads {
 		workloads = append(workloads, ws...)
+		helmChartName := helmSourceToChartName[source]
 
 		relSource, err := filepath.Rel(repoRoot, source)
 		if err == nil {
@@ -142,7 +143,7 @@ func (fileHandler *FileResourceHandler) GetResources(sessionObj *cautils.OPASess
 		workloadSource := reporthandling.Source{
 			RelativePath:  source,
 			FileType:      reporthandling.SourceTypeHelmChart,
-			HelmChartName: helmSourceToChartName[source],
+			HelmChartName: helmChartName,
 			LastCommit:    lastCommit,
 		}
 


### PR DESCRIPTION
Chart name map was accessed with the wrong key value (`source` is changed to `relSource`)