### PR TITLE
Update link for playground in Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Want to contribute? Want to discuss something? Have an issue?
 [Kubescape docs](https://hub.armosec.io/docs)
 
 ## Playground
-* [Kubescape playground](https://www.katacoda.com/pathaksaiyam/scenarios/kubescape)
+* [Kubescape playground](https://killercoda.com/saiyampathak/scenario/kubescape)
 
 ## Tutorials
 


### PR DESCRIPTION
Since katacoda.com is closed and the scenarios were moved to killercoda, this PR updates the link in the Readme.

Closes #564 